### PR TITLE
Update endpoints.js to suppress response_mode when value is none

### DIFF
--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -59,7 +59,6 @@ export class Endpoints {
       client_id: clientId,
       redirect_uri: redirectUri,
       state,
-      response_mode: responseMode,
       response_type: responseType,
       scope,
       prompt,
@@ -67,6 +66,9 @@ export class Endpoints {
       login_hint: loginHint,
       kc_idp_hint: idpHint,
       ui_locales: locale
+    }
+    if (responseMode !== 'none') {
+      query.response_mode = responseMode;
     }
     if (useNonce) {
       query.nonce = nonce


### PR DESCRIPTION
This change allows the request to include response_mode only when the option is different from none. The current implementation still includes the response_mode=none in the POST request and generates an error when used with Oracle IDCS